### PR TITLE
Add B2Sell SEO Assistant plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+b2sell-seo-assistant.zip

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# plugin-seo
+# B2Sell SEO Assistant Plugin
+
+Este repositorio contiene el plugin de WordPress **B2Sell SEO Assistant**.
+
+## Instalación
+1. Desde la raíz del repositorio, genera el archivo ZIP con:
+   ```bash
+   zip -r b2sell-seo-assistant.zip b2sell-seo-assistant
+   ```
+2. En el panel de administración de WordPress ve a **Plugins > Añadir nuevo > Subir plugin**.
+3. Selecciona el archivo ZIP y activa el plugin.
+
+El plugin agrega un menú **B2Sell SEO & SEM** con las siguientes secciones:
+- Dashboard
+- Análisis SEO
+- Generador de Contenido (GPT)
+- Campañas SEM
+- Configuración
+
+Cada página muestra el texto "Sección en desarrollo – B2SELL" y en el pie de página "Desarrollado por B2Sell SPA".

--- a/b2sell-seo-assistant/b2sell-seo-assistant.php
+++ b/b2sell-seo-assistant/b2sell-seo-assistant.php
@@ -1,0 +1,104 @@
+<?php
+/*
+Plugin Name: B2Sell SEO Assistant
+Description: Plugin para gestionar secciones de SEO y SEM.
+Version: 1.0.0
+Author: B2Sell SPA
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Salir si se accede directamente.
+}
+
+class B2Sell_SEO_Assistant {
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+    }
+
+    public function register_menu() {
+        add_menu_page(
+            'B2Sell SEO & SEM',
+            'B2Sell SEO & SEM',
+            'manage_options',
+            'b2sell-seo-assistant',
+            array( $this, 'dashboard_page' ),
+            'dashicons-chart-area'
+        );
+
+        add_submenu_page(
+            'b2sell-seo-assistant',
+            'Dashboard',
+            'Dashboard',
+            'manage_options',
+            'b2sell-seo-assistant',
+            array( $this, 'dashboard_page' )
+        );
+
+        add_submenu_page(
+            'b2sell-seo-assistant',
+            'Análisis SEO',
+            'Análisis SEO',
+            'manage_options',
+            'b2sell-seo-analisis',
+            array( $this, 'analisis_page' )
+        );
+
+        add_submenu_page(
+            'b2sell-seo-assistant',
+            'Generador de Contenido (GPT)',
+            'Generador de Contenido (GPT)',
+            'manage_options',
+            'b2sell-seo-gpt',
+            array( $this, 'gpt_page' )
+        );
+
+        add_submenu_page(
+            'b2sell-seo-assistant',
+            'Campañas SEM',
+            'Campañas SEM',
+            'manage_options',
+            'b2sell-seo-campanas',
+            array( $this, 'sem_page' )
+        );
+
+        add_submenu_page(
+            'b2sell-seo-assistant',
+            'Configuración',
+            'Configuración',
+            'manage_options',
+            'b2sell-seo-config',
+            array( $this, 'config_page' )
+        );
+    }
+
+    private function render_section( $title ) {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html( $title ) . '</h1>';
+        echo '<p>Sección en desarrollo – B2SELL</p>';
+        echo '<hr />';
+        echo '<p style="font-size:12px;color:#666;">Desarrollado por B2Sell SPA.</p>';
+        echo '</div>';
+    }
+
+    public function dashboard_page() {
+        $this->render_section( 'Dashboard' );
+    }
+
+    public function analisis_page() {
+        $this->render_section( 'Análisis SEO' );
+    }
+
+    public function gpt_page() {
+        $this->render_section( 'Generador de Contenido (GPT)' );
+    }
+
+    public function sem_page() {
+        $this->render_section( 'Campañas SEM' );
+    }
+
+    public function config_page() {
+        $this->render_section( 'Configuración' );
+    }
+}
+
+new B2Sell_SEO_Assistant();


### PR DESCRIPTION
## Summary
- add B2Sell SEO Assistant plugin with admin menu and five placeholder sections
- remove binary ZIP and document zip creation

## Testing
- `php -l b2sell-seo-assistant/b2sell-seo-assistant.php`


------
https://chatgpt.com/codex/tasks/task_e_68be3c1c94948330b8dbe07ea42dd685