### PR TITLE
feat: improve dashboard

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
@@ -54,8 +54,9 @@ class B2Sell_SEO_Analysis {
                 $history = array();
             }
             $history[] = array(
-                'date'  => current_time( 'mysql' ),
-                'score' => $results['score'],
+                'date'           => current_time( 'mysql' ),
+                'score'          => $results['score'],
+                'recommendations'=> array_slice( $results['recommendations'], 0, 3 ),
             );
             update_post_meta( $post_id, '_b2sell_seo_history', $history );
         }


### PR DESCRIPTION
## Summary
- add global SEO overview dashboard with recent analyses and recommendations
- store recommendations with each SEO analysis

## Testing
- `php -l b2sell-seo-assistant.php`
- `php -l includes/class-b2sell-seo-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68be419e2fbc8330805e64d2976f6e02