### PR TITLE
feat: enhance dashboard UI with gauge and recommendations

### DIFF
--- a/b2sell-seo-assistant/assets/css/admin.css
+++ b/b2sell-seo-assistant/assets/css/admin.css
@@ -10,13 +10,16 @@ body {
 }
 
 .b2sell-card {
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 20px;
+    margin-bottom: 20px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     transition: box-shadow 0.2s ease;
 }
 
 .b2sell-card:hover {
-    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
 }
 
 .button,
@@ -52,6 +55,18 @@ body {
     border-left: 4px solid #99cc66;
 }
 
+.b2sell-yellow,
+.b2sell-dashboard table .b2sell-yellow {
+    background: #fff8e5;
+    border-left: 4px solid #ffb900;
+}
+
+.b2sell-red,
+.b2sell-dashboard table .b2sell-red {
+    background: #ffe6e6;
+    border-left: 4px solid #dc3232;
+}
+
 .b2sell-footer {
     position: fixed;
     bottom: 0;
@@ -61,4 +76,91 @@ body {
     color: #ccc;
     text-align: center;
     padding: 10px 0;
+}
+
+/* Dashboard layout */
+.b2sell-dashboard-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.b2sell-dashboard-grid .b2sell-card {
+    flex: 1 1 300px;
+}
+
+.b2sell-score-card {
+    text-align: center;
+}
+
+/* Gauge styles */
+.b2sell-gauge {
+    max-width: 150px;
+    margin: 0 auto;
+}
+
+.b2sell-gauge-bg {
+    fill: none;
+    stroke: #eee;
+    stroke-width: 3.8;
+}
+
+.b2sell-gauge-bar {
+    fill: none;
+    stroke-width: 2.8;
+    stroke-linecap: round;
+    transform: rotate(-90deg);
+    transform-origin: center;
+}
+
+.b2sell-gauge-bar.b2sell-green {
+    stroke: #46b450;
+}
+
+.b2sell-gauge-bar.b2sell-yellow {
+    stroke: #ffb900;
+}
+
+.b2sell-gauge-bar.b2sell-red {
+    stroke: #dc3232;
+}
+
+.b2sell-gauge-text {
+    font-size: 0.5em;
+    font-weight: bold;
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* Recommendation list */
+.b2sell-recs li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.b2sell-recs li .dashicons {
+    margin-right: 8px;
+}
+
+.b2sell-recs ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
+
+/* GPT button */
+.b2sell-gpt-button {
+    background-color: #5450FF !important;
+    border-color: #5450FF !important;
+    font-family: Helvetica, Arial, sans-serif;
+    font-weight: bold;
+    color: #fff;
+    border-radius: 8px;
+}
+
+@media (max-width: 600px) {
+    .b2sell-dashboard-grid {
+        flex-direction: column;
+    }
 }

--- a/b2sell-seo-assistant/b2sell-seo-assistant.php
+++ b/b2sell-seo-assistant/b2sell-seo-assistant.php
@@ -132,21 +132,15 @@ class B2Sell_SEO_Assistant {
 
         echo '<div class="wrap b2sell-dashboard">';
         echo '<h1>B2SELL Dashboard</h1>';
-        echo '<style>
-        .b2sell-card{padding:20px;margin-bottom:20px;border-radius:8px;background:#fff;}
-        .b2sell-green{background:#e6ffed;border-left:4px solid #46b450;}
-        .b2sell-yellow{background:#fff8e5;border-left:4px solid #ffb900;}
-        .b2sell-red{background:#ffe6e6;border-left:4px solid #dc3232;}
-        .b2sell-score{font-size:32px;font-weight:bold;}
-        .b2sell-dashboard table .b2sell-green{background:#e6ffed;}
-        .b2sell-dashboard table .b2sell-yellow{background:#fff8e5;}
-        .b2sell-dashboard table .b2sell-red{background:#ffe6e6;}
-        .b2sell-recs ul{margin:0;padding-left:20px;}
-        </style>';
+        echo '<div class="b2sell-dashboard-grid">';
 
-        echo '<div class="b2sell-card b2sell-' . esc_attr( $avg_color ) . '">';
+        echo '<div class="b2sell-card b2sell-score-card">';
         echo '<h2>Puntaje SEO Global</h2>';
-        echo '<p class="b2sell-score">' . esc_html( $avg_score ) . '/100</p>';
+        echo '<svg viewBox="0 0 36 36" class="b2sell-gauge">';
+        echo '<path class="b2sell-gauge-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />';
+        echo '<path class="b2sell-gauge-bar b2sell-' . esc_attr( $avg_color ) . '" stroke-dasharray="' . esc_attr( $avg_score ) . ',100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />';
+        echo '<text x="18" y="20.35" class="b2sell-gauge-text">' . esc_html( $avg_score ) . '%</text>';
+        echo '</svg>';
         echo '</div>';
 
         echo '<div class="b2sell-card">';
@@ -165,14 +159,17 @@ class B2Sell_SEO_Assistant {
 
         if ( $latest && ! empty( $latest['recommendations'] ) ) {
             echo '<div class="b2sell-card b2sell-recs">';
-            echo '<h2>Recomendaciones recientes</h2><ul>';
-            foreach ( array_slice( $latest['recommendations'], 0, 3 ) as $rec ) {
-                echo '<li>' . esc_html( $rec ) . '</li>';
+            echo '<h2>Recomendaciones críticas</h2><ul>';
+            $icons = array( 'dashicons-warning', 'dashicons-info', 'dashicons-yes' );
+            foreach ( array_slice( $latest['recommendations'], 0, 3 ) as $idx => $rec ) {
+                $icon = $icons[ $idx % 3 ];
+                echo '<li><span class="dashicons ' . esc_attr( $icon ) . '"></span>' . esc_html( $rec ) . '</li>';
             }
             echo '</ul></div>';
         }
 
-        echo '<p><a class="button button-primary button-hero" href="' . esc_url( admin_url( 'admin.php?page=b2sell-seo-gpt' ) ) . '">Generar contenido con GPT</a></p>';
+        echo '</div>';
+        echo '<p><a class="button button-primary button-hero b2sell-gpt-button" href="' . esc_url( admin_url( 'admin.php?page=b2sell-seo-gpt' ) ) . '">Generar contenido con GPT</a></p>';
         echo '</div>';
     }
 


### PR DESCRIPTION
## Summary
- redesign dashboard layout with responsive cards
- display global SEO score in color-coded gauge chart
- add critical recommendations with icons and a GPT action button

## Testing
- `php -l b2sell-seo-assistant/b2sell-seo-assistant.php`


------
https://chatgpt.com/codex/tasks/task_e_68be50aae2788330a537a60c26b9fcda