### PR TITLE
feat: add image SEO analysis module

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-gpt.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-gpt.php
@@ -177,8 +177,14 @@ class B2Sell_GPT_Generator {
                 $dom->loadHTML( '<meta http-equiv="content-type" content="text/html; charset=utf-8" />' . $html );
                 libxml_clear_errors();
                 $imgs = $dom->getElementsByTagName( 'img' );
+                $target_src = sanitize_text_field( $_POST['image_src'] ?? '' );
                 foreach ( $imgs as $img ) {
-                    if ( '' === $img->getAttribute( 'alt' ) ) {
+                    if ( $target_src ) {
+                        if ( $img->getAttribute( 'src' ) === $target_src ) {
+                            $img->setAttribute( 'alt', $content );
+                            break;
+                        }
+                    } elseif ( '' === $img->getAttribute( 'alt' ) ) {
                         $img->setAttribute( 'alt', $content );
                         break;
                     }


### PR DESCRIPTION
## Summary
- add Image SEO submodule listing images without ALT and heavy assets
- generate ALT suggestions with GPT and allow direct insertion
- highlight image size/dimension issues with optimization tips

## Testing
- `php -l b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php`
- `php -l b2sell-seo-assistant/includes/class-b2sell-gpt.php`
- `npm test` *(fails: package.json missing)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b2428008330ae4f4bec3d2a2101