### PR TITLE
feat: add consolidated seo dashboard

### DIFF
--- a/b2sell-seo-assistant/assets/css/admin.css
+++ b/b2sell-seo-assistant/assets/css/admin.css
@@ -159,6 +159,13 @@ body {
     border-radius: 8px;
 }
 
+.b2sell-analyze-button {
+    background-color: #27ae60 !important;
+    border-color: #27ae60 !important;
+    color: #fff;
+    border-radius: 8px;
+}
+
 @media (max-width: 600px) {
     .b2sell-dashboard-grid {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- compute weighted sitewide SEO score and display gauge
- show technical and image summaries with quick indicators
- list urgent recommendations and run full-site analysis via dashboard

## Testing
- `php -l b2sell-seo-assistant/b2sell-seo-assistant.php`
- `php -l b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php`

------
https://chatgpt.com/codex/tasks/task_e_68bf8f2bbc488330a84ff5ea3b8371ed