### PR TITLE
feat: add competition analysis history

### DIFF
--- a/b2sell-seo-assistant/b2sell-seo-assistant.php
+++ b/b2sell-seo-assistant/b2sell-seo-assistant.php
@@ -15,6 +15,8 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-b2sell-sem.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-b2sell-editor-metabox.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-b2sell-competencia.php';
 
+register_activation_hook( __FILE__, array( 'B2Sell_Competencia', 'install' ) );
+
 class B2Sell_SEO_Assistant {
     private $analysis;
     private $gpt;

--- a/b2sell-seo-assistant/includes/class-b2sell-competencia.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-competencia.php
@@ -5,10 +5,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class B2Sell_Competencia {
 
+    private $table;
+
     public function __construct() {
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'b2sell_comp_history';
         add_action( 'wp_ajax_b2sell_competencia_search', array( $this, 'ajax_search' ) );
         add_action( 'wp_ajax_b2sell_competencia_optimize', array( $this, 'ajax_optimize' ) );
         add_action( 'wp_ajax_b2sell_competencia_insert', array( $this, 'ajax_insert' ) );
+        add_action( 'wp_ajax_b2sell_competencia_history_detail', array( $this, 'ajax_history_detail' ) );
+        add_action( 'wp_ajax_b2sell_competencia_reanalyze', array( $this, 'ajax_reanalyze' ) );
+    }
+
+    public static function install() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'b2sell_comp_history';
+        $charset_collate = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE $table (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            date DATETIME NOT NULL,
+            keyword VARCHAR(255) NOT NULL,
+            keywords LONGTEXT NOT NULL,
+            post_id BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+            results LONGTEXT NOT NULL,
+            my_rank INT NOT NULL DEFAULT 0,
+            PRIMARY KEY  (id),
+            KEY keyword (keyword)
+        ) $charset_collate;";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
     }
 
     public function render_admin_page() {
@@ -17,8 +42,8 @@ class B2Sell_Competencia {
             'post_status' => 'publish',
             'numberposts' => -1,
         ) );
-        $nonce     = wp_create_nonce( 'b2sell_competencia_nonce' );
-        $posts_js  = array();
+        $nonce    = wp_create_nonce( 'b2sell_competencia_nonce' );
+        $posts_js = array();
         foreach ( $posts as $p ) {
             $meta = get_post_meta( $p->ID, '_b2sell_meta_description', true );
             if ( ! $meta ) {
@@ -30,8 +55,13 @@ class B2Sell_Competencia {
                 'url'   => get_permalink( $p->ID ),
             );
         }
+        global $wpdb;
+        $history = $wpdb->get_results( "SELECT * FROM {$this->table} ORDER BY date DESC LIMIT 20" );
         echo '<div class="wrap">';
         echo '<h1>Competencia</h1>';
+        echo '<h2 class="nav-tab-wrapper"><a href="#" class="nav-tab nav-tab-active" data-tab="analysis">Análisis</a><a href="#" class="nav-tab" data-tab="history">Histórico</a></h2>';
+
+        echo '<div id="b2sell_comp_tab_analysis" class="b2sell-comp-tab">';
         echo '<p>Ingresa hasta 5 palabras clave (una por línea) y selecciona una página o post de tu sitio para comparar.</p>';
         echo '<textarea id="b2sell_comp_keywords" placeholder="Palabras clave" style="width:300px;height:100px;"></textarea> ';
         echo '<select id="b2sell_comp_post"><option value="">Selecciona un post/página</option>';
@@ -42,14 +72,42 @@ class B2Sell_Competencia {
         echo '<button class="button" id="b2sell_comp_search_btn">Buscar</button>';
         echo '<div id="b2sell_comp_results" style="margin-top:20px;"></div>';
         echo '</div>';
+
+        echo '<div id="b2sell_comp_tab_history" class="b2sell-comp-tab" style="display:none;">';
+        echo '<table class="widefat"><thead><tr><th>Fecha</th><th>Keyword</th><th>Ranking competidores</th><th>Acciones</th></tr></thead><tbody>';
+        if ( $history ) {
+            foreach ( $history as $row ) {
+                $results   = json_decode( $row->results, true );
+                $rank_html = '';
+                if ( $results ) {
+                    foreach ( $results as $res ) {
+                        $rank_html .= $res['rank'] . '. ' . esc_html( $res['title'] ) . '<br>';
+                    }
+                }
+                echo '<tr><td>' . esc_html( $row->date ) . '</td><td>' . esc_html( $row->keyword ) . '</td><td>' . $rank_html . '</td><td><button class="button b2sell_comp_detail" data-id="' . esc_attr( $row->id ) . '">Ver detalles</button> <button class="button b2sell_comp_rean" data-id="' . esc_attr( $row->id ) . '">Reanalizar</button></td></tr>';
+            }
+        } else {
+            echo '<tr><td colspan="4">Sin análisis previos.</td></tr>';
+        }
+        echo '</tbody></table>';
+        echo '</div>';
+
+        echo '</div>';
+
         echo '<div id="b2sell_comp_modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);">';
         echo '<div style="background:#fff;padding:20px;max-width:600px;margin:50px auto;">';
         echo '<h2>Sugerencias GPT</h2><div id="b2sell_comp_suggestions"></div>';
         echo '<button class="button" id="b2sell_comp_copy">Copiar</button> <button class="button" id="b2sell_comp_export">Exportar CSV</button> <button class="button button-primary" id="b2sell_comp_insert">Insertar en el contenido</button> <button class="button" id="b2sell_comp_close">Cerrar</button>';
         echo '</div></div>';
+
+        echo '<div id="b2sell_comp_hist_modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);">';
+        echo '<div style="background:#fff;padding:20px;max-width:800px;margin:50px auto;"><div id="b2sell_comp_hist_modal_content"></div><button class="button" id="b2sell_comp_hist_close">Cerrar</button></div></div>';
+
         echo '<script>var b2sellCompPosts=' . wp_json_encode( $posts_js ) . ';var b2sellCompNonce="' . esc_js( $nonce ) . '";var b2sellCompResults={};</script>';
+        echo '<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>';
         echo '<script>
         jQuery(function($){
+            $(".nav-tab-wrapper .nav-tab").on("click",function(e){e.preventDefault();var t=$(this).data("tab");$(".nav-tab").removeClass("nav-tab-active");$(this).addClass("nav-tab-active");$(".b2sell-comp-tab").hide();$("#b2sell_comp_tab_"+t).show();});
             $("#b2sell_comp_search_btn").on("click", function(){
                 var kws = $("#b2sell_comp_keywords").val().split(/\n+/)
                     .map(function(s){return $.trim(s);})
@@ -58,7 +116,7 @@ class B2Sell_Competencia {
                 var pid = $("#b2sell_comp_post").val();
                 if(!kws.length){return;}
                 $("#b2sell_comp_results").html("Buscando...");
-                $.post(ajaxurl,{action:"b2sell_competencia_search",keywords:kws,_wpnonce:b2sellCompNonce},function(res){
+                $.post(ajaxurl,{action:"b2sell_competencia_search",keywords:kws,post_id:pid,_wpnonce:b2sellCompNonce},function(res){
                     if(res.success){
                         b2sellCompResults = res.data;
                         var my = b2sellCompPosts[pid]||{title:"",meta:"",url:""};
@@ -67,9 +125,9 @@ class B2Sell_Competencia {
                             var list = res.data[kw] || [];
                             html += "<div class=\"b2sell-comp-block\" data-key=\""+kw+"\"><h2>"+kw+"</h2>";
                             if(list.length){
-                                html += "<table class=\"widefat\"><thead><tr><th>Título</th><th>Meta description</th><th>URL</th><th>Mi título</th><th>Mi meta</th><th>Mi URL</th></tr></thead><tbody>";
+                                html += "<table class=\"widefat\"><thead><tr><th>Posición</th><th>Título</th><th>Meta description</th><th>URL</th><th>Mi título</th><th>Mi meta</th><th>Mi URL</th></tr></thead><tbody>";
                                 list.forEach(function(r){
-                                    html += "<tr><td>"+r.title+"</td><td>"+r.snippet+"</td><td><a href=\""+r.link+"\" target=\"_blank\">"+r.link+"</a></td><td>"+my.title+"</td><td>"+my.meta+"</td><td>"+(my.url?"<a href=\\\""+my.url+"\\\" target=\\\"_blank\\\">"+my.url+"</a>":"")+"</td></tr>";
+                                    html += "<tr><td>"+r.rank+"</td><td>"+r.title+"</td><td>"+r.snippet+"</td><td><a href=\""+r.link+"\" target=\"_blank\">"+r.link+"</a></td><td>"+my.title+"</td><td>"+my.meta+"</td><td>"+(my.url?"<a href=\\\""+my.url+"\\\" target=\\\"_blank\\\">"+my.url+"</a>":"")+"</td></tr>";
                                 });
                                 html += "</tbody></table>";
                                 if(pid){html += "<button class=\"button b2sell_comp_opt_btn\" data-keyword=\""+kw+"\" style=\"margin-top:10px;\">Optimizar con GPT</button>";}
@@ -106,6 +164,28 @@ class B2Sell_Competencia {
             $("#b2sell_comp_copy").on("click",function(){var t=$("#b2sell_comp_suggestions").text();navigator.clipboard.writeText(t);});
             $("#b2sell_comp_export").on("click",function(){var s=$("#b2sell_comp_insert").data("suggestions")||{};var kw=$("#b2sell_comp_insert").data("keyword")||"";var csv="Keyword,Título,Meta description,Keywords relacionadas\n";var row=[kw,s.title||"",s.meta||"",(s.keywords||[]).join(" ")];for(var i=0;i<row.length;i++){row[i]="\""+String(row[i]).replace(/"/g,"\"\"")+"\"";}csv+=row.join(",")+"\n";var blob=new Blob([csv],{type:"text/csv"});var a=document.createElement("a");a.href=URL.createObjectURL(blob);a.download="gpt_sugerencias_"+kw+".csv";a.click();});
             $("#b2sell_comp_insert").on("click",function(){var pid=$(this).data("post"),title=$(this).data("title"),meta=$(this).data("meta");$.post(ajaxurl,{action:"b2sell_competencia_insert",post_id:pid,title:title,meta:meta,_wpnonce:b2sellCompNonce},function(){alert("Insertado" );});});
+            $(document).on("click",".b2sell_comp_detail",function(){
+                var id=$(this).data("id");
+                $.post(ajaxurl,{action:"b2sell_competencia_history_detail",id:id,_wpnonce:b2sellCompNonce},function(res){
+                    if(res.success){
+                        var r=res.data.record;
+                        var html="<h2>"+r.keyword+" - "+r.date+"</h2>";
+                        html+="<table class=\\"widefat\\"><thead><tr><th>Posición</th><th>Título</th><th>Meta</th><th>URL</th></tr></thead><tbody>";
+                        r.results.forEach(function(it){html+="<tr><td>"+it.rank+"</td><td>"+it.title+"</td><td>"+it.snippet+"</td><td><a href=\\""+it.link+"\\" target=\\"_blank\\">"+it.link+"</a></td></tr>";});
+                        html+="</tbody></table><canvas id=\\"b2sell_comp_chart\\" height=\\"100\\" style=\\"margin-top:20px\\"></canvas>";
+                        $("#b2sell_comp_hist_modal_content").html(html);
+                        $("#b2sell_comp_hist_modal").show();
+                        if(res.data.chart){
+                            var ctx=document.getElementById("b2sell_comp_chart").getContext("2d");
+                            var datasets=[{label:"Mi sitio",data:res.data.chart.my,borderColor:"#0073aa",fill:false}];
+                            if(res.data.chart.competitor&&res.data.chart.competitor.domain){datasets.push({label:res.data.chart.competitor.domain,data:res.data.chart.competitor.ranks,borderColor:"#cc0000",fill:false});}
+                            new Chart(ctx,{type:"line",data:{labels:res.data.chart.labels,datasets:datasets},options:{scales:{y:{reverse:true,beginAtZero:true}}}});
+                        }
+                    }else{alert(res.data);}
+                });
+            });
+            $("#b2sell_comp_hist_close").on("click",function(){$("#b2sell_comp_hist_modal").hide();});
+            $(document).on("click",".b2sell_comp_rean",function(){var id=$(this).data("id");if(!confirm("Reanalizar esta keyword?")){return;}$.post(ajaxurl,{action:"b2sell_competencia_reanalyze",id:id,_wpnonce:b2sellCompNonce},function(res){if(res.success){location.reload();}else{alert(res.data);}});});
         });
         </script>';
     }
@@ -116,6 +196,7 @@ class B2Sell_Competencia {
             wp_send_json_error( 'Permisos insuficientes' );
         }
         $keywords = isset( $_POST['keywords'] ) ? array_slice( array_filter( array_map( 'sanitize_text_field', (array) $_POST['keywords'] ) ), 0, 5 ) : array();
+        $post_id  = intval( $_POST['post_id'] ?? 0 );
         $api_key  = get_option( 'b2sell_google_api_key', '' );
         $cx       = get_option( 'b2sell_google_cx', '' );
         if ( empty( $keywords ) ) {
@@ -125,6 +206,7 @@ class B2Sell_Competencia {
             wp_send_json_error( 'API Key o CX no configurados' );
         }
         $results = array();
+        $my_url  = $post_id ? get_permalink( $post_id ) : '';
         foreach ( $keywords as $keyword ) {
             $url      = add_query_arg(
                 array(
@@ -140,22 +222,170 @@ class B2Sell_Competencia {
                 $results[ $keyword ] = array();
                 continue;
             }
-            $data  = json_decode( wp_remote_retrieve_body( $response ), true );
-            $items = $data['items'] ?? array();
+            $data      = json_decode( wp_remote_retrieve_body( $response ), true );
+            $items     = $data['items'] ?? array();
             $kw_results = array();
-            foreach ( $items as $item ) {
+            $my_rank    = 0;
+            foreach ( $items as $index => $item ) {
+                $link   = $item['link'] ?? '';
+                $domain = parse_url( $link, PHP_URL_HOST );
+                $rank   = $index + 1;
+                if ( $my_url && trailingslashit( $link ) === trailingslashit( $my_url ) ) {
+                    $my_rank = $rank;
+                }
                 $kw_results[] = array(
                     'title'   => $item['title'] ?? '',
                     'snippet' => $item['snippet'] ?? '',
-                    'link'    => $item['link'] ?? '',
+                    'link'    => $link,
+                    'domain'  => $domain,
+                    'rank'    => $rank,
                 );
             }
             $results[ $keyword ] = $kw_results;
+            global $wpdb;
+            $wpdb->insert(
+                $this->table,
+                array(
+                    'date'     => current_time( 'mysql' ),
+                    'keyword'  => $keyword,
+                    'keywords' => wp_json_encode( $keywords ),
+                    'post_id'  => $post_id,
+                    'results'  => wp_json_encode( $kw_results ),
+                    'my_rank'  => $my_rank,
+                )
+            );
         }
         if ( empty( $results ) ) {
             wp_send_json_error( 'Sin resultados' );
         }
         wp_send_json_success( $results );
+    }
+
+    public function ajax_history_detail() {
+        check_ajax_referer( 'b2sell_competencia_nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Permisos insuficientes' );
+        }
+        $id = intval( $_POST['id'] ?? 0 );
+        if ( ! $id ) {
+            wp_send_json_error( 'ID inválido' );
+        }
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$this->table} WHERE id=%d", $id ) );
+        if ( ! $row ) {
+            wp_send_json_error( 'Registro no encontrado' );
+        }
+        $record = array(
+            'date'    => $row->date,
+            'keyword' => $row->keyword,
+            'results' => json_decode( $row->results, true ),
+            'post_id' => (int) $row->post_id,
+            'my_rank' => (int) $row->my_rank,
+        );
+        $history_rows = $wpdb->get_results( $wpdb->prepare( "SELECT date,my_rank,results FROM {$this->table} WHERE keyword=%s ORDER BY date ASC", $row->keyword ) );
+        $labels       = array();
+        $my_ranks     = array();
+        $comp_domain  = '';
+        $comp_ranks   = array();
+        foreach ( $history_rows as $h ) {
+            $labels[]   = $h->date;
+            $my_ranks[] = (int) $h->my_rank;
+            $items      = json_decode( $h->results, true );
+            if ( ! $comp_domain && ! empty( $items ) ) {
+                $comp_domain = $items[0]['domain'] ?? '';
+            }
+            $rank = null;
+            if ( $comp_domain ) {
+                foreach ( $items as $it ) {
+                    if ( ( $it['domain'] ?? '' ) === $comp_domain ) {
+                        $rank = (int) $it['rank'];
+                        break;
+                    }
+                }
+            }
+            $comp_ranks[] = $rank;
+        }
+        wp_send_json_success(
+            array(
+                'record' => $record,
+                'chart'  => array(
+                    'labels'     => $labels,
+                    'my'         => $my_ranks,
+                    'competitor' => array(
+                        'domain' => $comp_domain,
+                        'ranks'  => $comp_ranks,
+                    ),
+                ),
+            )
+        );
+    }
+
+    public function ajax_reanalyze() {
+        check_ajax_referer( 'b2sell_competencia_nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Permisos insuficientes' );
+        }
+        $id = intval( $_POST['id'] ?? 0 );
+        if ( ! $id ) {
+            wp_send_json_error( 'ID inválido' );
+        }
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$this->table} WHERE id=%d", $id ) );
+        if ( ! $row ) {
+            wp_send_json_error( 'Registro no encontrado' );
+        }
+        $keyword = $row->keyword;
+        $post_id = (int) $row->post_id;
+        $api_key = get_option( 'b2sell_google_api_key', '' );
+        $cx      = get_option( 'b2sell_google_cx', '' );
+        if ( ! $api_key || ! $cx ) {
+            wp_send_json_error( 'API Key o CX no configurados' );
+        }
+        $url      = add_query_arg(
+            array(
+                'key' => $api_key,
+                'cx'  => $cx,
+                'q'   => $keyword,
+                'num' => 5,
+            ),
+            'https://www.googleapis.com/customsearch/v1'
+        );
+        $response = wp_remote_get( $url );
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_error( 'Error en consulta' );
+        }
+        $data      = json_decode( wp_remote_retrieve_body( $response ), true );
+        $items     = $data['items'] ?? array();
+        $kw_results = array();
+        $my_rank    = 0;
+        $my_url     = $post_id ? get_permalink( $post_id ) : '';
+        foreach ( $items as $index => $item ) {
+            $link   = $item['link'] ?? '';
+            $domain = parse_url( $link, PHP_URL_HOST );
+            $rank   = $index + 1;
+            if ( $my_url && trailingslashit( $link ) === trailingslashit( $my_url ) ) {
+                $my_rank = $rank;
+            }
+            $kw_results[] = array(
+                'title'   => $item['title'] ?? '',
+                'snippet' => $item['snippet'] ?? '',
+                'link'    => $link,
+                'domain'  => $domain,
+                'rank'    => $rank,
+            );
+        }
+        $wpdb->insert(
+            $this->table,
+            array(
+                'date'     => current_time( 'mysql' ),
+                'keyword'  => $keyword,
+                'keywords' => $row->keywords,
+                'post_id'  => $post_id,
+                'results'  => wp_json_encode( $kw_results ),
+                'my_rank'  => $my_rank,
+            )
+        );
+        wp_send_json_success();
     }
 
     public function ajax_optimize() {


### PR DESCRIPTION
## Summary
- store Google search results with ranking in new competition history table
- add Histórico tab with past analyses, detail modal, chart and reanalyze action
- create database table on plugin activation

## Testing
- `php -l b2sell-seo-assistant.php`
- `php -l includes/class-b2sell-competencia.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf9fbf1794833080f99097524c0c27