### PR TITLE
Add GPT-powered SEO title and meta generation

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-gpt.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-gpt.php
@@ -88,6 +88,12 @@ class B2Sell_GPT_Generator {
         $action    = sanitize_text_field( $_POST['gpt_action'] ?? '' );
         $keyword   = sanitize_text_field( $_POST['keyword'] ?? '' );
         $paragraph = sanitize_textarea_field( $_POST['paragraph'] ?? '' );
+        $post_id   = intval( $_POST['post_id'] ?? 0 );
+        if ( ! $keyword && $post_id ) {
+            $post    = get_post( $post_id );
+            $keyword = $post ? wp_strip_all_tags( $post->post_content ) : '';
+        }
+        $keyword = mb_substr( $keyword, 0, 800 );
         $api_key   = get_option( 'b2sell_openai_api_key', '' );
         if ( ! $api_key ) {
             wp_send_json_error( array( 'message' => 'API Key no configurada' ) );
@@ -97,7 +103,7 @@ class B2Sell_GPT_Generator {
                 $prompt = 'Genera un título atractivo y optimizado para SEO sobre: ' . $keyword;
                 break;
             case 'meta':
-                $prompt = 'Escribe una meta descripción optimizada para SEO (máximo 155 caracteres) sobre: ' . $keyword;
+                $prompt = 'Escribe una meta descripción optimizada para SEO (máximo 160 caracteres) sobre: ' . $keyword;
                 break;
             case 'rewrite':
                 $prompt = 'Reescribe el siguiente párrafo mejorando el SEO y usando mejores palabras clave:\n\n' . $paragraph;
@@ -141,6 +147,11 @@ class B2Sell_GPT_Generator {
             wp_send_json_error( array( 'message' => 'Respuesta inválida de OpenAI' ) );
         }
         $content = trim( $data['choices'][0]['message']['content'] );
+        if ( 'title' === $action ) {
+            $content = mb_substr( $content, 0, 60 );
+        } elseif ( 'meta' === $action ) {
+            $content = mb_substr( $content, 0, 160 );
+        }
         wp_send_json_success( array( 'content' => $content ) );
     }
 

--- a/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
@@ -104,11 +104,11 @@ class B2Sell_SEO_Analysis {
         echo '<div id="b2sell-history" style="display:none;margin-top:20px;"><canvas id="b2sell-history-chart" height="100"></canvas></div>';
 
         echo '<h2 style="margin-top:40px;">Metadatos SEO</h2>';
-        echo '<table class="widefat" id="b2sell-meta-table"><thead><tr><th>Título</th><th>Título SEO</th><th>Meta description</th><th></th></tr></thead><tbody>';
+        echo '<table class="widefat" id="b2sell-meta-table"><thead><tr><th>Título</th><th>Título SEO</th><th>Meta description</th><th>Acciones</th></tr></thead><tbody>';
         foreach ( $posts as $p ) {
             $t = get_post_meta( $p->ID, '_b2sell_seo_title', true );
             $d = get_post_meta( $p->ID, '_b2sell_seo_description', true );
-            echo '<tr data-id="' . esc_attr( $p->ID ) . '"><td>' . esc_html( $p->post_title ) . '</td><td class="b2sell-meta-title">' . esc_html( $t ) . '</td><td class="b2sell-meta-desc">' . esc_html( $d ) . '</td><td><button class="button b2sell-meta-edit">Editar</button></td></tr>';
+            echo '<tr data-id="' . esc_attr( $p->ID ) . '"><td>' . esc_html( $p->post_title ) . '</td><td class="b2sell-meta-title">' . esc_html( $t ) . '</td><td class="b2sell-meta-desc">' . esc_html( $d ) . '</td><td><button class="button b2sell-meta-edit">Editar</button> <button class="button b2sell-meta-gpt">Generar con GPT</button></td></tr>';
         }
         echo '</tbody></table>';
 
@@ -120,11 +120,99 @@ class B2Sell_SEO_Analysis {
         echo '<div class="b2sell-snippet-preview"><div class="b2sell-snippet-tabs"><button type="button" class="b2sell-snippet-tab active" data-view="desktop">Vista Desktop</button><button type="button" class="b2sell-snippet-tab" data-view="mobile">Vista Móvil</button></div><div class="b2sell-snippet-desktop b2sell-snippet-view"><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-desc"></span></div><div class="b2sell-snippet-mobile b2sell-snippet-view" style="display:none;"><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-desc"></span></div></div>';
         echo '<p><button class="button button-primary" id="b2sell-meta-save">Guardar</button> <button class="button" id="b2sell-meta-cancel">Cancelar</button></p>';
         echo '</div></div>';
+        echo '<div id="b2sell-meta-gpt" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:100000;">';
+        echo '<div style="background:#fff;padding:20px;max-width:600px;width:90%;max-height:90%;overflow:auto;">';
+        echo '<h2>Sugerencias GPT</h2>';
+        echo '<p><label>Título SEO<br/><input type="text" id="b2sell-gpt-modal-title" style="width:100%;" /></label> <small><span id="b2sell-gpt-title-count">0</span> caracteres</small></p>';
+        echo '<p><label>Meta description<br/><textarea id="b2sell-gpt-modal-desc" rows="3" style="width:100%;"></textarea></label> <small><span id="b2sell-gpt-desc-count">0</span> caracteres</small></p>';
+        echo '<div class="b2sell-snippet-preview"><div class="b2sell-snippet-tabs"><button type="button" class="b2sell-snippet-tab active" data-view="desktop">Vista Desktop</button><button type="button" class="b2sell-snippet-tab" data-view="mobile">Vista Móvil</button></div><div class="b2sell-snippet-desktop b2sell-snippet-view"><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-desc"></span></div><div class="b2sell-snippet-mobile b2sell-snippet-view" style="display:none;"><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-desc"></span></div></div>';
+        echo '<p><button class="button button-primary" id="b2sell-gpt-save">Guardar</button> <button class="button" id="b2sell-gpt-cancel">Cerrar</button></p>';
+        echo '</div></div>';
 
         $nonce = wp_create_nonce( 'b2sell_seo_meta' );
         echo '<script>var b2sellSeoNonce="' . esc_js( $nonce ) . '";</script>';
         echo '<style>.b2sell-snippet-preview{margin-top:20px;font-family:Arial,sans-serif}.b2sell-snippet-tabs{margin-bottom:10px}.b2sell-snippet-tabs button{margin-right:5px}.b2sell-snippet-view{border:1px solid #ccc;padding:10px}.b2sell-snippet-desktop{max-width:600px}.b2sell-snippet-mobile{max-width:360px}.b2sell-snippet-title{color:#5450FF;font-size:18px;margin-bottom:2px;display:block}.b2sell-snippet-url{color:green;font-size:14px;margin-bottom:2px;display:block}.b2sell-snippet-desc{color:#5f6368;font-size:13px;line-height:1.4}.b2sell-snippet-desktop .b2sell-snippet-desc{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}.b2sell-snippet-tab.active{font-weight:bold}</style>';
-        echo '<script>jQuery(function($){var currentId=0;function updateModal(){var t=$("#b2sell-meta-modal-title").val();var d=$("#b2sell-meta-modal-desc").val();$("#b2sell-modal-title-count").text(t.length);$("#b2sell-modal-desc-count").text(d.length);$("#b2sell-meta-modal .b2sell-snippet-title").text(t);$("#b2sell-meta-modal .b2sell-snippet-desc").text(d);}$("#b2sell-meta-table").on("click",".b2sell-meta-edit",function(){var row=$(this).closest("tr");currentId=row.data("id");$("#b2sell-meta-modal-title").val(row.find(".b2sell-meta-title").text());$("#b2sell-meta-modal-desc").val(row.find(".b2sell-meta-desc").text());$("#b2sell-meta-modal").css("display","flex");updateModal();});$("#b2sell-meta-cancel").on("click",function(){$("#b2sell-meta-modal").hide();});$("#b2sell-meta-modal-title,#b2sell-meta-modal-desc").on("input",updateModal);$("#b2sell-meta-save").on("click",function(){$.post(ajaxurl,{action:"b2sell_save_seo_meta",post_id:currentId,title:$("#b2sell-meta-modal-title").val(),description:$("#b2sell-meta-modal-desc").val(),nonce:b2sellSeoNonce},function(res){alert(res.success?"Guardado":"Error");if(res.success){var row=$("#b2sell-meta-table tr[data-id=\'"+currentId+"\']");row.find(".b2sell-meta-title").text($("#b2sell-meta-modal-title").val());row.find(".b2sell-meta-desc").text($("#b2sell-meta-modal-desc").val());}$("#b2sell-meta-modal").hide();});});$(".b2sell-snippet-tab").on("click",function(){var v=$(this).data("view");$(".b2sell-snippet-tab").removeClass("active");$(this).addClass("active");$(".b2sell-snippet-view").hide();$(".b2sell-snippet-"+v).show();});});</script>';
+        ?>
+        <script>
+        jQuery(function($){
+            var currentId=0;
+            function updateModal(){
+                var t=$('#b2sell-meta-modal-title').val();
+                var d=$('#b2sell-meta-modal-desc').val();
+                $('#b2sell-modal-title-count').text(t.length);
+                $('#b2sell-modal-desc-count').text(d.length);
+                $('#b2sell-meta-modal .b2sell-snippet-title').text(t);
+                $('#b2sell-meta-modal .b2sell-snippet-desc').text(d);
+            }
+            function updateGpt(){
+                var t=$('#b2sell-gpt-modal-title').val();
+                var d=$('#b2sell-gpt-modal-desc').val();
+                $('#b2sell-gpt-title-count').text(t.length);
+                $('#b2sell-gpt-desc-count').text(d.length);
+                $('#b2sell-meta-gpt .b2sell-snippet-title').text(t);
+                $('#b2sell-meta-gpt .b2sell-snippet-desc').text(d);
+            }
+            $('#b2sell-meta-table').on('click','.b2sell-meta-edit',function(){
+                var row=$(this).closest('tr');
+                currentId=row.data('id');
+                $('#b2sell-meta-modal-title').val(row.find('.b2sell-meta-title').text());
+                $('#b2sell-meta-modal-desc').val(row.find('.b2sell-meta-desc').text());
+                $('#b2sell-meta-modal').css('display','flex');
+                updateModal();
+            });
+            $('#b2sell-meta-table').on('click','.b2sell-meta-gpt',function(){
+                var row=$(this).closest('tr');
+                currentId=row.data('id');
+                $('#b2sell-gpt-modal-title').val('');
+                $('#b2sell-gpt-modal-desc').val('');
+                $('#b2sell-meta-gpt').css('display','flex');
+                updateGpt();
+                $.when(
+                    $.post(ajaxurl,{action:'b2sell_gpt_generate',gpt_action:'title',post_id:currentId,_wpnonce:b2sellSeoNonce}),
+                    $.post(ajaxurl,{action:'b2sell_gpt_generate',gpt_action:'meta',post_id:currentId,_wpnonce:b2sellSeoNonce})
+                ).done(function(tRes,mRes){
+                    if(tRes[0].success){$('#b2sell-gpt-modal-title').val(tRes[0].data.content);}
+                    if(mRes[0].success){$('#b2sell-gpt-modal-desc').val(mRes[0].data.content);}
+                    updateGpt();
+                });
+            });
+            $('#b2sell-meta-cancel').on('click',function(){ $('#b2sell-meta-modal').hide(); });
+            $('#b2sell-gpt-cancel').on('click',function(){ $('#b2sell-meta-gpt').hide(); });
+            $('#b2sell-meta-modal-title,#b2sell-meta-modal-desc').on('input',updateModal);
+            $('#b2sell-gpt-modal-title,#b2sell-gpt-modal-desc').on('input',updateGpt);
+            $('#b2sell-meta-save').on('click',function(){
+                $.post(ajaxurl,{action:'b2sell_save_seo_meta',post_id:currentId,title:$('#b2sell-meta-modal-title').val(),description:$('#b2sell-meta-modal-desc').val(),nonce:b2sellSeoNonce},function(res){
+                    alert(res.success?'Guardado':'Error');
+                    if(res.success){
+                        var row=$('#b2sell-meta-table tr[data-id='+currentId+']');
+                        row.find('.b2sell-meta-title').text($('#b2sell-meta-modal-title').val());
+                        row.find('.b2sell-meta-desc').text($('#b2sell-meta-modal-desc').val());
+                    }
+                    $('#b2sell-meta-modal').hide();
+                });
+            });
+            $('#b2sell-gpt-save').on('click',function(){
+                $.post(ajaxurl,{action:'b2sell_save_seo_meta',post_id:currentId,title:$('#b2sell-gpt-modal-title').val(),description:$('#b2sell-gpt-modal-desc').val(),nonce:b2sellSeoNonce},function(res){
+                    alert(res.success?'Guardado':'Error');
+                    if(res.success){
+                        var row=$('#b2sell-meta-table tr[data-id='+currentId+']');
+                        row.find('.b2sell-meta-title').text($('#b2sell-gpt-modal-title').val());
+                        row.find('.b2sell-meta-desc').text($('#b2sell-gpt-modal-desc').val());
+                    }
+                    $('#b2sell-meta-gpt').hide();
+                });
+            });
+            $(document).on('click','.b2sell-snippet-tab',function(){
+                var v=$(this).data('view');
+                var wrap=$(this).closest('.b2sell-snippet-preview');
+                wrap.find('.b2sell-snippet-tab').removeClass('active');
+                $(this).addClass('active');
+                wrap.find('.b2sell-snippet-view').hide();
+                wrap.find('.b2sell-snippet-'+v).show();
+            });
+        });
+        </script>
+        <?php
 
         $logo = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAA8CAIAAACsOWLGAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABSElEQVR4nO3b0WqDMBiG4Wbs/m/ZHQghSzTWdh8r+jxnbRQKfdG/KZZlWR7w177++wNwTcIiQlhECIsIYREhLCKERYSwiBAWEcIiQlhECIsIYREhLCKERYSwiBAWEcIiQlhECIsIYREhLCK+58ullO6d7nGx9oB2ae/E8f1uafNxtMkSn+kgrFX9RksppZT25aPJoi6NHXQnSuTyzt0K2266eiYXpHVVTLfy1BWramMSChNPhbU3SI3H1ObWe197wN4EJtBLemvGqsahapzxzVi38vqMVfnJxujdfSxVselcWF1Ge1WNAxZ3szEw/Vre3yCd7CxMTjzcID27xGc6CAte479CIoRFhLCIEBYRwiJCWEQIiwhhESEsIoRFhLCIEBYRwiJCWEQIiwhhESEsIoRFhLCIEBYRwiJCWEQIiwhhESEsIoRFxA9KdYd0WrGpfwAAAABJRU5ErkJggg==';
         echo '<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>';


### PR DESCRIPTION
## Summary
- allow GPT to suggest SEO titles and meta descriptions
- add GPT generation buttons and modal previews in post editor and analysis list
- enforce 60/160 character limits for generated text

## Testing
- `php -l b2sell-seo-assistant/includes/class-b2sell-gpt.php`
- `php -l b2sell-seo-assistant/includes/class-b2sell-editor-metabox.php`
- `php -l b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0e9a7eea08330983cf768c8429bec