### PR TITLE
Add localization options for competition search

### DIFF
--- a/b2sell-seo-assistant/b2sell-seo-assistant.php
+++ b/b2sell-seo-assistant/b2sell-seo-assistant.php
@@ -220,17 +220,27 @@ class B2Sell_SEO_Assistant {
         $pagespeed_key = get_option( 'b2sell_pagespeed_api_key', '' );
         $google_key    = get_option( 'b2sell_google_api_key', '' );
         $google_cx     = get_option( 'b2sell_google_cx', '' );
+        $google_gl     = get_option( 'b2sell_google_gl', 'cl' );
+        $google_hl     = get_option( 'b2sell_google_hl', 'es' );
         $ads_dev       = get_option( 'b2sell_ads_developer_token', '' );
         $ads_client    = get_option( 'b2sell_ads_client_id', '' );
         $ads_secret    = get_option( 'b2sell_ads_client_secret', '' );
         $ads_refresh   = get_option( 'b2sell_ads_refresh_token', '' );
         $ads_customer  = get_option( 'b2sell_ads_customer_id', '' );
-        if ( isset( $_POST['b2sell_openai_api_key'] ) || isset( $_POST['b2sell_pagespeed_api_key'] ) || isset( $_POST['b2sell_google_api_key'] ) || isset( $_POST['b2sell_google_cx'] ) || isset( $_POST['b2sell_ads_developer_token'] ) ) {
+        if ( isset( $_POST['b2sell_openai_api_key'] ) || isset( $_POST['b2sell_pagespeed_api_key'] ) || isset( $_POST['b2sell_google_api_key'] ) || isset( $_POST['b2sell_google_cx'] ) || isset( $_POST['b2sell_google_gl'] ) || isset( $_POST['b2sell_google_hl'] ) || isset( $_POST['b2sell_ads_developer_token'] ) ) {
             check_admin_referer( 'b2sell_save_api_key' );
             $openai_key    = sanitize_text_field( $_POST['b2sell_openai_api_key'] ?? '' );
             $pagespeed_key = sanitize_text_field( $_POST['b2sell_pagespeed_api_key'] ?? '' );
             $google_key    = sanitize_text_field( $_POST['b2sell_google_api_key'] ?? '' );
             $google_cx     = sanitize_text_field( $_POST['b2sell_google_cx'] ?? '' );
+            $google_gl     = sanitize_text_field( $_POST['b2sell_google_gl'] ?? '' );
+            $google_hl     = sanitize_text_field( $_POST['b2sell_google_hl'] ?? '' );
+            if ( '' === $google_gl ) {
+                $google_gl = 'cl';
+            }
+            if ( '' === $google_hl ) {
+                $google_hl = 'es';
+            }
             $ads_dev       = sanitize_text_field( $_POST['b2sell_ads_developer_token'] ?? '' );
             $ads_client    = sanitize_text_field( $_POST['b2sell_ads_client_id'] ?? '' );
             $ads_secret    = sanitize_text_field( $_POST['b2sell_ads_client_secret'] ?? '' );
@@ -240,6 +250,8 @@ class B2Sell_SEO_Assistant {
             update_option( 'b2sell_pagespeed_api_key', $pagespeed_key );
             update_option( 'b2sell_google_api_key', $google_key );
             update_option( 'b2sell_google_cx', $google_cx );
+            update_option( 'b2sell_google_gl', $google_gl );
+            update_option( 'b2sell_google_hl', $google_hl );
             update_option( 'b2sell_ads_developer_token', $ads_dev );
             update_option( 'b2sell_ads_client_id', $ads_client );
             update_option( 'b2sell_ads_client_secret', $ads_secret );
@@ -259,6 +271,10 @@ class B2Sell_SEO_Assistant {
         echo '<input type="text" id="b2sell_google_api_key" name="b2sell_google_api_key" value="' . esc_attr( $google_key ) . '" style="width:400px;" /></p>';
         echo '<p><label for="b2sell_google_cx">ID del motor de búsqueda (CX):</label> ';
         echo '<input type="text" id="b2sell_google_cx" name="b2sell_google_cx" value="' . esc_attr( $google_cx ) . '" style="width:400px;" /></p>';
+        echo '<p><label for="b2sell_google_gl">Código de país para búsqueda (gl):</label> ';
+        echo '<input type="text" id="b2sell_google_gl" name="b2sell_google_gl" value="' . esc_attr( $google_gl ) . '" style="width:400px;" /></p>';
+        echo '<p><label for="b2sell_google_hl">Idioma (hl):</label> ';
+        echo '<input type="text" id="b2sell_google_hl" name="b2sell_google_hl" value="' . esc_attr( $google_hl ) . '" style="width:400px;" /></p>';
         echo '<h2>Google Ads Keyword Planner</h2>';
         echo '<p><label for="b2sell_ads_developer_token">Developer Token:</label> ';
         echo '<input type="text" id="b2sell_ads_developer_token" name="b2sell_ads_developer_token" value="' . esc_attr( $ads_dev ) . '" style="width:400px;" /></p>';

--- a/b2sell-seo-assistant/includes/class-b2sell-competencia.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-competencia.php
@@ -284,6 +284,10 @@ class B2Sell_Competencia {
         $post_id  = intval( $_POST['post_id'] ?? 0 );
         $api_key  = get_option( 'b2sell_google_api_key', '' );
         $cx       = get_option( 'b2sell_google_cx', '' );
+        $gl       = get_option( 'b2sell_google_gl', 'cl' );
+        $hl       = get_option( 'b2sell_google_hl', 'es' );
+        $gl       = $gl ? $gl : 'cl';
+        $hl       = $hl ? $hl : 'es';
         if ( empty( $keywords ) ) {
             wp_send_json_error( 'Palabras clave vacías' );
         }
@@ -300,6 +304,8 @@ class B2Sell_Competencia {
                     'cx'  => $cx,
                     'q'   => $keyword,
                     'num' => 5,
+                    'gl'  => $gl,
+                    'hl'  => $hl,
                 ),
                 'https://www.googleapis.com/customsearch/v1'
             );
@@ -436,6 +442,10 @@ class B2Sell_Competencia {
         $post_id = (int) $row->post_id;
         $api_key = get_option( 'b2sell_google_api_key', '' );
         $cx      = get_option( 'b2sell_google_cx', '' );
+        $gl      = get_option( 'b2sell_google_gl', 'cl' );
+        $hl      = get_option( 'b2sell_google_hl', 'es' );
+        $gl      = $gl ? $gl : 'cl';
+        $hl      = $hl ? $hl : 'es';
         if ( ! $api_key || ! $cx ) {
             wp_send_json_error( 'API Key o CX no configurados' );
         }
@@ -445,6 +455,8 @@ class B2Sell_Competencia {
                 'cx'  => $cx,
                 'q'   => $keyword,
                 'num' => 5,
+                'gl'  => $gl,
+                'hl'  => $hl,
             ),
             'https://www.googleapis.com/customsearch/v1'
         );


### PR DESCRIPTION
## Summary
- Add configurable country and language settings for Google Custom Search.
- Include gl/hl parameters with defaults (cl/es) in competition API calls.
- Expose new configuration fields alongside existing API key settings.

## Testing
- `php -l b2sell-seo-assistant/b2sell-seo-assistant.php`
- `php -l b2sell-seo-assistant/includes/class-b2sell-competencia.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0f0d23f948330b8920baea474081c