### PR TITLE
Add SEO metadata length validation and preview truncation

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
@@ -115,16 +115,16 @@ class B2Sell_SEO_Analysis {
         echo '<div id="b2sell-meta-modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:100000;">';
         echo '<div style="background:#fff;padding:20px;max-width:600px;width:90%;max-height:90%;overflow:auto;">';
         echo '<h2>Editar metadatos</h2>';
-        echo '<p><label>Título SEO<br /><input type="text" id="b2sell-meta-modal-title" style="width:100%;" /></label><br /><small><span id="b2sell-modal-title-count">0</span> caracteres</small></p>';
-        echo '<p><label>Meta description<br /><textarea id="b2sell-meta-modal-desc" style="width:100%;" rows="3"></textarea></label><br /><small><span id="b2sell-modal-desc-count">0</span> caracteres</small></p>';
+        echo '<p><label>Título SEO<br /><input type="text" id="b2sell-meta-modal-title" style="width:100%;" /></label><br /><small><span id="b2sell-modal-title-count">0</span> caracteres</small><div id="b2sell-modal-title-warning" style="color:#c00;display:none;">Se recomienda máximo 60 caracteres para el título</div></p>';
+        echo '<p><label>Meta description<br /><textarea id="b2sell-meta-modal-desc" style="width:100%;" rows="3"></textarea></label><br /><small><span id="b2sell-modal-desc-count">0</span> caracteres</small><div id="b2sell-modal-desc-warning" style="color:#c00;display:none;">Se recomienda máximo 160 caracteres para la meta description</div></p>';
         echo '<div class="b2sell-snippet-preview"><div class="b2sell-snippet-tabs"><button type="button" class="b2sell-snippet-tab active" data-view="desktop">Vista Desktop</button><button type="button" class="b2sell-snippet-tab" data-view="mobile">Vista Móvil</button></div><div class="b2sell-snippet-desktop b2sell-snippet-view"><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-desc"></span></div><div class="b2sell-snippet-mobile b2sell-snippet-view" style="display:none;"><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-desc"></span></div></div>';
         echo '<p><button class="button button-primary" id="b2sell-meta-save">Guardar</button> <button class="button" id="b2sell-meta-cancel">Cancelar</button></p>';
         echo '</div></div>';
         echo '<div id="b2sell-meta-gpt" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:100000;">';
         echo '<div style="background:#fff;padding:20px;max-width:600px;width:90%;max-height:90%;overflow:auto;">';
         echo '<h2>Sugerencias GPT</h2>';
-        echo '<p><label>Título SEO<br/><input type="text" id="b2sell-gpt-modal-title" style="width:100%;" /></label> <small><span id="b2sell-gpt-title-count">0</span> caracteres</small></p>';
-        echo '<p><label>Meta description<br/><textarea id="b2sell-gpt-modal-desc" rows="3" style="width:100%;"></textarea></label> <small><span id="b2sell-gpt-desc-count">0</span> caracteres</small></p>';
+        echo '<p><label>Título SEO<br/><input type="text" id="b2sell-gpt-modal-title" style="width:100%;" /></label> <small><span id="b2sell-gpt-title-count">0</span> caracteres</small><div id="b2sell-gpt-title-warning" style="color:#c00;display:none;">Se recomienda máximo 60 caracteres para el título</div></p>';
+        echo '<p><label>Meta description<br/><textarea id="b2sell-gpt-modal-desc" rows="3" style="width:100%;"></textarea></label> <small><span id="b2sell-gpt-desc-count">0</span> caracteres</small><div id="b2sell-gpt-desc-warning" style="color:#c00;display:none;">Se recomienda máximo 160 caracteres para la meta description</div></p>';
         echo '<div class="b2sell-snippet-preview"><div class="b2sell-snippet-tabs"><button type="button" class="b2sell-snippet-tab active" data-view="desktop">Vista Desktop</button><button type="button" class="b2sell-snippet-tab" data-view="mobile">Vista Móvil</button></div><div class="b2sell-snippet-desktop b2sell-snippet-view"><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-desc"></span></div><div class="b2sell-snippet-mobile b2sell-snippet-view" style="display:none;"><span class="b2sell-snippet-url">' . esc_html( home_url() ) . '</span><span class="b2sell-snippet-title"></span><span class="b2sell-snippet-desc"></span></div></div>';
         echo '<p><button class="button button-primary" id="b2sell-gpt-save">Guardar</button> <button class="button" id="b2sell-gpt-cancel">Cerrar</button></p>';
         echo '</div></div>';
@@ -136,21 +136,26 @@ class B2Sell_SEO_Analysis {
         <script>
         jQuery(function($){
             var currentId=0;
+            function truncate(str,max){return str.length>max?str.substring(0,max).trim()+"...":str;}
             function updateModal(){
                 var t=$('#b2sell-meta-modal-title').val();
                 var d=$('#b2sell-meta-modal-desc').val();
-                $('#b2sell-modal-title-count').text(t.length);
-                $('#b2sell-modal-desc-count').text(d.length);
-                $('#b2sell-meta-modal .b2sell-snippet-title').text(t);
-                $('#b2sell-meta-modal .b2sell-snippet-desc').text(d);
+                $('#b2sell-modal-title-count').text(t.length).css('color',t.length>60?'red':'');
+                $('#b2sell-modal-title-warning').toggle(t.length>60);
+                $('#b2sell-modal-desc-count').text(d.length).css('color',d.length>160?'red':'');
+                $('#b2sell-modal-desc-warning').toggle(d.length>160);
+                $('#b2sell-meta-modal .b2sell-snippet-title').text(truncate(t,60));
+                $('#b2sell-meta-modal .b2sell-snippet-desc').text(truncate(d,160));
             }
             function updateGpt(){
                 var t=$('#b2sell-gpt-modal-title').val();
                 var d=$('#b2sell-gpt-modal-desc').val();
-                $('#b2sell-gpt-title-count').text(t.length);
-                $('#b2sell-gpt-desc-count').text(d.length);
-                $('#b2sell-meta-gpt .b2sell-snippet-title').text(t);
-                $('#b2sell-meta-gpt .b2sell-snippet-desc').text(d);
+                $('#b2sell-gpt-title-count').text(t.length).css('color',t.length>60?'red':'');
+                $('#b2sell-gpt-title-warning').toggle(t.length>60);
+                $('#b2sell-gpt-desc-count').text(d.length).css('color',d.length>160?'red':'');
+                $('#b2sell-gpt-desc-warning').toggle(d.length>160);
+                $('#b2sell-meta-gpt .b2sell-snippet-title').text(truncate(t,60));
+                $('#b2sell-meta-gpt .b2sell-snippet-desc').text(truncate(d,160));
             }
             $('#b2sell-meta-table').on('click','.b2sell-meta-edit',function(){
                 var row=$(this).closest('tr');


### PR DESCRIPTION
## Summary
- add length validation and warnings for SEO title and meta description
- truncate overflowing text in desktop and mobile snippet previews

## Testing
- `php -l includes/class-b2sell-seo-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0f4f4c7a08330b84c36c1db31709b