### PR TITLE
feat: improve GPT metadata generation

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-gpt.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-gpt.php
@@ -8,6 +8,7 @@ class B2Sell_GPT_Generator {
     public function __construct() {
         add_action( 'wp_ajax_b2sell_gpt_generate', array( $this, 'ajax_generate' ) );
         add_action( 'wp_ajax_b2sell_gpt_insert', array( $this, 'ajax_insert' ) );
+        add_action( 'wp_ajax_b2sell_generate_meta', array( $this, 'ajax_generate_meta' ) );
     }
 
     public function render_admin_page() {
@@ -153,6 +154,74 @@ class B2Sell_GPT_Generator {
             $content = mb_substr( $content, 0, 160 );
         }
         wp_send_json_success( array( 'content' => $content ) );
+    }
+
+    public function ajax_generate_meta() {
+        check_ajax_referer( 'b2sell_seo_meta' );
+        $post_id = intval( $_POST['post_id'] ?? 0 );
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            wp_send_json_error( array( 'message' => 'Permisos insuficientes' ) );
+        }
+        $content = sanitize_textarea_field( wp_unslash( $_POST['content'] ?? '' ) );
+        if ( ! $content && $post_id ) {
+            $post    = get_post( $post_id );
+            $content = $post ? wp_strip_all_tags( $post->post_content ) : '';
+        }
+        $content = mb_substr( $content, 0, 1200 );
+        $api_key = get_option( 'b2sell_openai_api_key', '' );
+        if ( ! $api_key ) {
+            wp_send_json_error( array( 'message' => 'API Key no configurada' ) );
+        }
+        $prompt = 'Basado en el siguiente contenido genera un título SEO (máximo 60 caracteres) y una meta description (máximo 160 caracteres). Devuelve un JSON con las claves "title" y "description":\n\n' . $content;
+        $response = wp_remote_post( 'https://api.openai.com/v1/chat/completions', array(
+            'headers' => array(
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $api_key,
+            ),
+            'body'    => wp_json_encode( array(
+                'model'    => 'gpt-3.5-turbo',
+                'messages' => array(
+                    array( 'role' => 'user', 'content' => $prompt ),
+                ),
+            ) ),
+            'timeout' => 30,
+        ) );
+        if ( is_wp_error( $response ) ) {
+            $error_message = $response->get_error_message();
+            if ( false !== stripos( $error_message, 'timed out' ) || false !== stripos( $error_message, 'timeout' ) ) {
+                $msg = 'La solicitud a OpenAI demoró demasiado (timeout). Intenta nuevamente o aumenta los recursos del servidor.';
+            } else {
+                $msg = 'Error de conexión con OpenAI: tu servidor no logra conectarse. Revisa el firewall del hosting y asegúrate de permitir salida HTTPS hacia api.openai.com (puerto 443).';
+            }
+            wp_send_json_error( array( 'message' => $msg ) );
+        }
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( isset( $data['error']['message'] ) ) {
+            wp_send_json_error( array( 'message' => $data['error']['message'] ) );
+        }
+        if ( ! isset( $data['choices'][0]['message']['content'] ) ) {
+            wp_send_json_error( array( 'message' => 'Respuesta inválida de OpenAI' ) );
+        }
+        $raw  = trim( $data['choices'][0]['message']['content'] );
+        $json = json_decode( $raw, true );
+        if ( ! is_array( $json ) ) {
+            $json = array();
+            $lines = array_map( 'trim', explode( "\n", $raw ) );
+            foreach ( $lines as $line ) {
+                if ( stripos( $line, 'title' ) === 0 || stripos( $line, 'título' ) === 0 ) {
+                    $json['title'] = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
+                }
+                if ( stripos( $line, 'description' ) === 0 || stripos( $line, 'descripción' ) === 0 ) {
+                    $json['description'] = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
+                }
+            }
+        }
+        $title = isset( $json['title'] ) ? mb_substr( $json['title'], 0, 60 ) : '';
+        $desc  = isset( $json['description'] ) ? mb_substr( $json['description'], 0, 160 ) : '';
+        if ( '' === $title && '' === $desc ) {
+            wp_send_json_error( array( 'message' => 'Respuesta inválida de OpenAI' ) );
+        }
+        wp_send_json_success( array( 'title' => $title, 'description' => $desc ) );
     }
 
     public function ajax_insert() {


### PR DESCRIPTION
## Summary
- send post ID and content when generating metadata suggestions
- add backend endpoint to produce SEO title and description from OpenAI
- show suggestions in modal with snippet preview and apply button

## Testing
- `php -l includes/class-b2sell-seo-analysis.php`
- `php -l includes/class-b2sell-gpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0f70826248330b9615dc857815632