### PR TITLE
Add Google Custom Search option checks

### DIFF
--- a/b2sell-seo-assistant/b2sell-seo-assistant.php
+++ b/b2sell-seo-assistant/b2sell-seo-assistant.php
@@ -267,6 +267,8 @@ class B2Sell_SEO_Assistant {
         echo '<input type="text" id="b2sell_openai_api_key" name="b2sell_openai_api_key" value="' . esc_attr( $openai_key ) . '" style="width:400px;" /></p>';
         echo '<p><label for="b2sell_pagespeed_api_key">Google PageSpeed API Key:</label> ';
         echo '<input type="text" id="b2sell_pagespeed_api_key" name="b2sell_pagespeed_api_key" value="' . esc_attr( $pagespeed_key ) . '" style="width:400px;" /></p>';
+        echo '<h2>Google Custom Search</h2>';
+        echo '<p>La <strong>API Key</strong> y el <strong>ID del motor de búsqueda (CX)</strong> son necesarios para realizar la búsqueda de competencia. Obtén estos valores en <a href="https://developers.google.com/custom-search/v1/introduction" target="_blank">Google Custom Search</a>.</p>';
         echo '<p><label for="b2sell_google_api_key">Google Custom Search API Key:</label> ';
         echo '<input type="text" id="b2sell_google_api_key" name="b2sell_google_api_key" value="' . esc_attr( $google_key ) . '" style="width:400px;" /></p>';
         echo '<p><label for="b2sell_google_cx">ID del motor de búsqueda (CX):</label> ';

--- a/b2sell-seo-assistant/includes/class-b2sell-competencia.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-competencia.php
@@ -139,9 +139,15 @@ class B2Sell_Competencia {
                 'url'   => get_permalink( $p->ID ),
             );
         }
+        $api_key = get_option( 'b2sell_google_api_key', '' );
+        $cx      = get_option( 'b2sell_google_cx', '' );
         global $wpdb;
         $history = $wpdb->get_results( "SELECT * FROM {$this->table} ORDER BY date DESC LIMIT 20" );
         echo '<div class="wrap">';
+        if ( ! $api_key || ! $cx ) {
+            $link = esc_url( admin_url( 'admin.php?page=b2sell-seo-config' ) );
+            echo '<div class="error"><p>Google Custom Search no está configurado. Configura la API Key y el ID del motor de búsqueda (CX) en la <a href="' . $link . '">página de Configuración</a>.</p></div>';
+        }
         echo '<h1>Competencia</h1>';
         echo '<h2 class="nav-tab-wrapper"><a href="#" class="nav-tab nav-tab-active" data-tab="analysis">Análisis</a><a href="#" class="nav-tab" data-tab="history">Histórico</a></h2>';
 
@@ -320,7 +326,7 @@ class B2Sell_Competencia {
             wp_send_json_error( 'Palabras clave vacías' );
         }
         if ( ! $api_key || ! $cx ) {
-            wp_send_json_error( 'API Key o CX no configurados' );
+            wp_send_json_error( 'API Key o CX no configurados. Configura los valores en la página de Configuración.' );
         }
         $results = array();
         $my_url  = $post_id ? get_permalink( $post_id ) : '';


### PR DESCRIPTION
## Summary
- Warn in Competencia admin page when Google Custom Search API Key or CX are missing
- Mention configuration page in AJAX error
- Document required Google Custom Search fields in configuration

## Testing
- `php -l b2sell-seo-assistant/includes/class-b2sell-competencia.php`
- `php -l b2sell-seo-assistant/b2sell-seo-assistant.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0fbaa2d3c8330a1dd7601b7c2d55f