### PR TITLE
feat: add competitor comparison chart

### DIFF
--- a/b2sell-seo-assistant/assets/css/admin.css
+++ b/b2sell-seo-assistant/assets/css/admin.css
@@ -93,6 +93,17 @@ body {
     text-align: center;
 }
 
+/* Charts side by side */
+.b2sell-history-charts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.b2sell-history-charts > div {
+    flex: 1 1 300px;
+}
+
 /* Gauge styles */
 .b2sell-gauge {
     max-width: 150px;


### PR DESCRIPTION
## Summary
- show competitor ranking chart alongside score history
- fetch competitor history and expose via dashboard
- style charts side-by-side

## Testing
- `php -l b2sell-seo-assistant.php`
- `php -l includes/class-b2sell-competencia.php`

------
https://chatgpt.com/codex/tasks/task_e_68c0fd27cdcc8330a7ccc22d50865579