### PR TITLE
Fix HTML string for Competencia traffic chart

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-competencia.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-competencia.php
@@ -285,7 +285,7 @@ class B2Sell_Competencia {
                                 html += \"<p>No se encontraron resultados para esta keyword</p>\";
                             }
                             if(flow){
-                                html += \"<canvas class=\\"b2sell-comp-flow\\" data-key=\\"\"+kw+\"\\" height=\\"100\\" style=\\"margin-top:20px\\"></canvas><div class=\\"b2sell-comp-interpret\\" data-key=\\"\"+kw+\"\\" style=\\"margin-top:10px\\"></div>\";
+                                html += "<canvas class=\"b2sell-comp-flow\" data-key=\""+kw+"\" height=\"100\" style=\"margin-top:20px\"></canvas><div class=\"b2sell-comp-interpret\" data-key=\""+kw+"\" style=\"margin-top:10px\"></div>";
                             }
                             html += \"</div>\";
                         });


### PR DESCRIPTION
## Summary
- fix traffic chart HTML string in Competencia admin page to remove stray quote and missing space

## Testing
- `php -l includes/class-b2sell-competencia.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0ffd6c20c8330bcc64a5c51ff4450