### PR TITLE
Fix HTML strings in Competencia admin page

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-competencia.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-competencia.php
@@ -282,12 +282,12 @@ class B2Sell_Competencia {
                                 html += "</tbody></table>";
                                 if(pid){html += "<button class=\\"button b2sell_comp_opt_btn\\" data-keyword=\\""+kw+"\\" style=\\"margin-top:10px;\\">Optimizar con GPT</button>";}
                             }else{
-                                html += \"<p>No se encontraron resultados para esta keyword</p>\";
+                                html += "<p>No se encontraron resultados para esta keyword</p>";
                             }
                             if(flow){
-                                html += \"<canvas class=\\"b2sell-comp-flow\\" data-key=\\"\"+kw+\"\\" height=\\"100\\" style=\\"margin-top:20px\\"></canvas><div class=\\"b2sell-comp-interpret\\" data-key=\\"\"+kw+\"\\" style=\\"margin-top:10px\\"></div>\";
+                                html += "<canvas class=\"b2sell-comp-flow\" data-key=\""+kw+"\" height=\"100\" style=\"margin-top:20px\"></canvas><div class=\"b2sell-comp-interpret\" data-key=\""+kw+"\" style=\"margin-top:10px\"></div>";
                             }
-                            html += \"</div>\";
+                            html += "</div>";
                         });
                         $("#b2sell_comp_results").html(html);
                         Object.keys(b2sellCompFlows).forEach(function(key){


### PR DESCRIPTION
## Summary
- fix traffic chart HTML string in Competencia admin page to remove stray quote and missing space
- remove unnecessary escaping for empty-result message and div closing

## Testing
- `php -l includes/class-b2sell-competencia.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0ffd6c20c8330bcc64a5c51ff4450