### PR TITLE
Add detail links to SEO analysis tables

### DIFF
--- a/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
@@ -146,11 +146,11 @@ class B2Sell_SEO_Analysis {
             );
             $history = esc_attr( wp_json_encode( $row['history'] ) );
             echo '<tr class="b2sell-history-row" data-history="' . $history . '">';
-            echo '<td>' . esc_html( $row['title'] ) . '</td>';
+            echo '<td><a class="b2sell-detail-link" href="' . esc_url( $link ) . '">' . esc_html( $row['title'] ) . '</a></td>';
             echo '<td>' . esc_html( $row['type'] ) . '</td>';
             echo '<td>' . esc_html( $row['date'] ) . '</td>';
             echo '<td>' . esc_html( $row['score'] ) . '</td>';
-            echo '<td><a class="button" href="' . esc_url( $link ) . '">Analizar</a></td>';
+            echo '<td><a class="button button-secondary" href="' . esc_url( $link ) . '">Ver detalle</a> <a class="button" href="' . esc_url( $link ) . '">Analizar</a></td>';
             echo '</tr>';
         }
         echo '</tbody></table>';
@@ -211,12 +211,12 @@ class B2Sell_SEO_Analysis {
                 admin_url( 'admin.php' )
             );
             echo '<tr data-id="' . esc_attr( $product->ID ) . '">';
-            echo '<td>' . esc_html( $product->post_title ) . '</td>';
+            echo '<td><a class="b2sell-detail-link" href="' . esc_url( $analyze ) . '">' . esc_html( $product->post_title ) . '</a></td>';
             echo '<td>' . esc_html( $sku ) . '</td>';
             echo '<td>' . esc_html( $date ) . '</td>';
             echo '<td>' . esc_html( $score ) . '</td>';
             echo '<td class="b2sell-product-missing">' . esc_html( $missing ) . '</td>';
-            echo '<td><a class="button" href="' . esc_url( $analyze ) . '">Analizar</a> <button class="button b2sell-product-alt" data-id="' . esc_attr( $product->ID ) . '">Generar ALT</button></td>';
+            echo '<td><a class="button button-secondary" href="' . esc_url( $analyze ) . '">Ver detalle</a> <a class="button" href="' . esc_url( $analyze ) . '">Analizar</a> <button class="button b2sell-product-alt" data-id="' . esc_attr( $product->ID ) . '">Generar ALT</button></td>';
             echo '</tr>';
         }
 


### PR DESCRIPTION
## Summary
- make the content and product titles clickable so users can open the analysis detail view
- add a dedicated "Ver detalle" button alongside the existing "Analizar" action for clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e93352d08330bdff8aae12c9877f