### PR TITLE
Adjust visibility index chart sizing

### DIFF
--- a/b2sell-seo-assistant/assets/css/admin.css
+++ b/b2sell-seo-assistant/assets/css/admin.css
@@ -104,6 +104,27 @@ body {
     flex: 1 1 300px;
 }
 
+.b2sell-comp-visibility-container {
+    margin-top: 30px;
+    max-width: 560px;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.b2sell-comp-visibility-canvas {
+    width: 100% !important;
+    height: 200px !important;
+}
+
+.b2sell-comp-visibility-values {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 10px;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
 /* Gauge styles */
 .b2sell-gauge {
     max-width: 150px;

--- a/b2sell-seo-assistant/includes/class-b2sell-competencia.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-competencia.php
@@ -971,10 +971,10 @@ class B2Sell_Competencia {
                             html += '</tbody></table>';
                         }
                         html += '</div></div>';
-                        html += '<div id="b2sell_comp_visibility_container" style="margin-top:30px;">';
+                        html += '<div id="b2sell_comp_visibility_container" class="b2sell-comp-visibility-container">';
                         html += '<h3>Índice de visibilidad</h3>';
-                        html += '<canvas id="b2sell_comp_visibility_chart" height="140"></canvas>';
-                        html += '<div id="b2sell_comp_visibility_values" style="display:flex;justify-content:space-around;margin-top:10px;"></div>';
+                        html += '<canvas id="b2sell_comp_visibility_chart" class="b2sell-comp-visibility-canvas"></canvas>';
+                        html += '<div id="b2sell_comp_visibility_values" class="b2sell-comp-visibility-values"></div>';
                         html += '</div>';
                         html += '<div id="b2sell_comp_visibility_trend" style="margin-top:30px;">';
                         html += '<h3>Evolución del índice de visibilidad</h3>';


### PR DESCRIPTION
## Summary
- limit the competition visibility index chart container to a narrower width with a fixed height
- move inline layout rules to the shared admin stylesheet for reuse and easier tuning

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e3ebf1e9a48330996b10d1acbc672a