### PR TITLE
Fix blog preview image overflow

### DIFF
--- a/b2sell-seo-assistant/assets/css/admin.css
+++ b/b2sell-seo-assistant/assets/css/admin.css
@@ -342,6 +342,11 @@ body {
     color: #455064;
 }
 
+.crear-blog-preview__content img {
+    max-width: 100%;
+    height: auto;
+}
+
 
 .crear-blog-preview__content .b2sell-blog-article {
     background: #ffffff;


### PR DESCRIPTION
## Summary
- constrain images within the blog preview content to the container width to avoid overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f48af8b083308d46e7c04d3c7565