### PR TITLE
Adjust SEO analysis speed charts layout

### DIFF
--- a/b2sell-seo-assistant/assets/css/admin.css
+++ b/b2sell-seo-assistant/assets/css/admin.css
@@ -104,6 +104,29 @@ body {
     flex: 1 1 300px;
 }
 
+.b2sell-speed-wrapper {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    align-items: start;
+}
+
+.b2sell-speed-item {
+    background: #fff;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.b2sell-speed-item canvas {
+    width: 100% !important;
+    height: auto !important;
+}
+
+.b2sell-speed-summary ul {
+    margin-top: 0;
+}
+
 .b2sell-comp-visibility-container {
     margin-top: 30px;
     max-width: 560px;

--- a/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
+++ b/b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php
@@ -877,8 +877,13 @@ class B2Sell_SEO_Analysis {
             if ( $ps ) {
                 echo '<h2>Velocidad y rendimiento</h2>';
                 echo '<div class="b2sell-speed-wrapper">';
+                echo '<div class="b2sell-speed-item">';
                 echo '<canvas id="b2sell-speed-score" width="200" height="120"></canvas>';
+                echo '</div>';
+                echo '<div class="b2sell-speed-item">';
                 echo '<canvas id="b2sell-speed-bars" height="120"></canvas>';
+                echo '</div>';
+                echo '<div class="b2sell-speed-item b2sell-speed-summary">';
                 echo '<ul>';
                 echo '<li>Performance score: <span style="color:' . esc_attr( $ps['score_color'] ) . ';">' . esc_html( $ps['score'] ) . '</span></li>';
                 echo '<li>TTFB: <span style="color:' . esc_attr( $ps['ttfb_color'] ) . ';">' . esc_html( $ps['ttfb'] ) . ' ms</span></li>';
@@ -893,6 +898,7 @@ class B2Sell_SEO_Analysis {
                     }
                     echo '</ul>';
                 }
+                echo '</div>';
                 echo '</div>';
                 echo '<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>';
                 echo '<script>';


### PR DESCRIPTION
## Summary
- wrap the SEO analysis speed and performance charts in dedicated containers for a two-column layout
- add admin styles to arrange the charts and metrics grid and keep canvases responsive

## Testing
- php -l b2sell-seo-assistant/includes/class-b2sell-seo-analysis.php

------
https://chatgpt.com/codex/tasks/task_e_68e4101eae8c83308b1bad35c0b54a29